### PR TITLE
maxresdefault vs hqdefault

### DIFF
--- a/src/VueLazyYoutubeVideo.vue
+++ b/src/VueLazyYoutubeVideo.vue
@@ -4,12 +4,12 @@
       <template v-if="!isVideoLoaded">
         <picture>
           <source
-            :srcset="`https://i.ytimg.com/vi_webp/${id}/maxresdefault.webp`"
+            :srcset="`https://i.ytimg.com/vi_webp/${id}/hqdefault.webp`"
             type="image/webp"
           >
           <img
             class="y-video__media"
-            src="`https://i.ytimg.com/vi/${id}/maxresdefault.jpg`"
+            src="`https://i.ytimg.com/vi/${id}/hqdefault.jpg`"
             :alt="alt"
           >
         </picture>

--- a/src/VueLazyYoutubeVideo.vue
+++ b/src/VueLazyYoutubeVideo.vue
@@ -9,7 +9,7 @@
           >
           <img
             class="y-video__media"
-            src="`https://i.ytimg.com/vi/${id}/hqdefault.jpg`"
+            :src="`https://i.ytimg.com/vi/${id}/hqdefault.jpg`"
             :alt="alt"
           >
         </picture>

--- a/src/VueLazyYoutubeVideo.vue
+++ b/src/VueLazyYoutubeVideo.vue
@@ -9,7 +9,7 @@
           >
           <img
             class="y-video__media"
-            src="https://i.ytimg.com/vi/4JS70KB9GS0/maxresdefault.jpg"
+            src="`https://i.ytimg.com/vi/${id}/maxresdefault.jpg`"
             :alt="alt"
           >
         </picture>


### PR DESCRIPTION
Only 1080 videos have the maxresdefault thumbnail and will not work on most of the yt videos.
I've taken a look in yt html and even they use the hqdefault thumbnail.

Also, if the web explorer cantt use the webp and tries the jpg it shows an image from other yt video (4JS70KB9GS0)